### PR TITLE
fix for qtype and qclass in response

### DIFF
--- a/dnsserver.js
+++ b/dnsserver.js
@@ -241,8 +241,8 @@ var buildResponseBuffer = function(response) {
     //end header
 
     response.question.qname.copy(buf, 12, 0, qnameLen);
-    response.question.qtype.copy(buf, 12+qnameLen, response.question.qtype, 2);
-    response.question.qclass.copy(buf, 12+qnameLen+2, response.question.qclass, 2);
+    response.question.qtype.copy(buf, 12+qnameLen);
+    response.question.qclass.copy(buf, 12+qnameLen+2);
 
     var rrStart = 12+qnameLen+4;
     

--- a/dnsserver.js
+++ b/dnsserver.js
@@ -241,8 +241,8 @@ var buildResponseBuffer = function(response) {
     //end header
 
     response.question.qname.copy(buf, 12, 0, qnameLen);
-    response.question.qtype.copy(buf, 12+qnameLen);
-    response.question.qclass.copy(buf, 12+qnameLen+2);
+    response.question.qtype.copy(buf, 12+qnameLen, 0, 2);
+    response.question.qclass.copy(buf, 12+qnameLen+2, 0, 2);
 
     var rrStart = 12+qnameLen+4;
     


### PR DESCRIPTION
Fix to copy to get the right qtype and qclass into the query-part of the DNS-response.
